### PR TITLE
feat: Add coreGCPProject, dockerRegistry constants

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,8 +15,10 @@
 ### Variables
 
 * [adminEmail](README.md#const-adminemail)
+* [coreGCPProject](README.md#const-coregcpproject)
 * [coreStackRef](README.md#const-corestackref)
 * [coreZone](README.md#const-corezone)
+* [dockerRegistry](README.md#const-dockerregistry)
 * [folderId](README.md#const-folderid)
 * [githubAdmin](README.md#const-githubadmin)
 * [githubOrg](README.md#const-githuborg)
@@ -42,6 +44,14 @@ Default administrator email
 
 ___
 
+### `Const` coreGCPProject
+
+• **coreGCPProject**: *"tabetalt-core"* = "tabetalt-core"
+
+Core GCP Project
+
+___
+
 ### `Const` coreStackRef
 
 • **coreStackRef**: *"bjerk-simen/tabetalt-core"* = "bjerk-simen/tabetalt-core"
@@ -55,6 +65,14 @@ ___
 • **coreZone**: *"tabetalt-no"* = "tabetalt-no"
 
 Core Managed Zone
+
+___
+
+### `Const` dockerRegistry
+
+• **dockerRegistry**: *string* = `eu.gcr.io/${coreGCPProject}`
+
+Docker registry
 
 ___
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,11 @@
 export const coreStackRef = 'bjerk-simen/tabetalt-core';
 
 /**
+ * Core GCP Project
+ */
+export const coreGCPProject = 'tabetalt-core';
+
+/**
  * Primary domain
  * eg. {env}.tabetalt.no
  */
@@ -48,7 +53,13 @@ export const version = 'v1' || process.env.VERSION;
  * Github Organization
  */
 export const githubOrg = 'tabetalt';
+
 /**
  * Github Admin
  */
 export const githubAdmin = 'cobraz';
+
+/**
+ * Docker registry
+ */
+export const dockerRegistry = `eu.gcr.io/${coreGCPProject}`;


### PR DESCRIPTION
This is required to implement tabetalt/infra-services#2 and to be in accordance with tabetalt/arch-docs#1